### PR TITLE
Fix #13 & revamp configuration

### DIFF
--- a/Controller/ForgotPasswordController.php
+++ b/Controller/ForgotPasswordController.php
@@ -18,8 +18,8 @@ class ForgotPasswordController
     private $validator;
     private $normalizer;
     private $groups;
-    private $emailFieldName;
-    private $passwordFieldName;
+    private $userEmailField;
+    private $userPasswordField;
 
     /**
      * @param ForgotPasswordManager $forgotPasswordManager
@@ -27,8 +27,8 @@ class ForgotPasswordController
      * @param ValidatorInterface    $validator
      * @param NormalizerInterface   $normalizer
      * @param array                 $groups
-     * @param string                $emailFieldName
-     * @param string                $passwordFieldName
+     * @param string                $userEmailField
+     * @param string                $userPasswordField
      */
     public function __construct(
         ForgotPasswordManager $forgotPasswordManager,
@@ -36,16 +36,16 @@ class ForgotPasswordController
         ValidatorInterface $validator,
         NormalizerInterface $normalizer,
         array $groups,
-        $emailFieldName,
-        $passwordFieldName
+        $userEmailField,
+        $userPasswordField
     ) {
         $this->forgotPasswordManager = $forgotPasswordManager;
         $this->passwordTokenManager = $passwordTokenManager;
         $this->validator = $validator;
         $this->normalizer = $normalizer;
         $this->groups = $groups;
-        $this->emailFieldName = $emailFieldName;
-        $this->passwordFieldName = $passwordFieldName;
+        $this->userEmailField = $userEmailField;
+        $this->userPasswordField = $userPasswordField;
     }
 
     /**
@@ -56,14 +56,14 @@ class ForgotPasswordController
     public function resetPasswordAction(Request $request)
     {
         $data = json_decode($request->getContent(), true);
-        if (isset($data[$this->emailFieldName]) && true === $this->forgotPasswordManager->resetPassword(
-                $data[$this->emailFieldName]
+        if (isset($data[$this->userEmailField]) && true === $this->forgotPasswordManager->resetPassword(
+                $data[$this->userEmailField]
             )
         ) {
             return new Response('', 204);
         }
 
-        return new JsonResponse([$this->emailFieldName => 'Invalid'], 400);
+        return new JsonResponse([$this->userEmailField => 'Invalid'], 400);
     }
 
     /**
@@ -76,7 +76,7 @@ class ForgotPasswordController
     public function getTokenAction($tokenValue)
     {
         $token = $this->passwordTokenManager->findOneByToken($tokenValue);
-        if (null === $token || 0 < count($this->validator->validate($token))) {
+        if (null === $token || 0 < $this->validator->validate($token)->count()) {
             throw new NotFoundHttpException('Invalid token.');
         }
 
@@ -96,19 +96,19 @@ class ForgotPasswordController
     public function updatePasswordAction($tokenValue, Request $request)
     {
         $token = $this->passwordTokenManager->findOneByToken($tokenValue);
-        if (null === $token || 0 < count($this->validator->validate($token))) {
+        if (null === $token || 0 < $this->validator->validate($token)->count()) {
             throw new NotFoundHttpException('Invalid token.');
         }
 
         $data = json_decode($request->getContent(), true);
-        if (isset($data[$this->passwordFieldName]) && true === $this->forgotPasswordManager->updatePassword(
+        if (isset($data[$this->userPasswordField]) && true === $this->forgotPasswordManager->updatePassword(
                 $token,
-                $data[$this->passwordFieldName]
+                $data[$this->userPasswordField]
             )
         ) {
             return new Response('', 204);
         }
 
-        return new JsonResponse([$this->passwordFieldName => 'Invalid'], 400);
+        return new JsonResponse([$this->userPasswordField => 'Invalid'], 400);
     }
 }

--- a/DependencyInjection/CoopTilleulsForgotPasswordExtension.php
+++ b/DependencyInjection/CoopTilleulsForgotPasswordExtension.php
@@ -18,12 +18,14 @@ class CoopTilleulsForgotPasswordExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         // Build parameters
-        $container->setParameter('coop_tilleuls_forgot_password.password_token_class', $config['password_token_class']);
-        $container->setParameter('coop_tilleuls_forgot_password.user_class', $config['user_class']);
-        $container->setParameter('coop_tilleuls_forgot_password.email_field', $config['email_field']);
-        $container->setParameter('coop_tilleuls_forgot_password.password_field', $config['password_field']);
-        $container->setParameter('coop_tilleuls_forgot_password.expires_in', $config['expires_in']);
-        $container->setParameter('coop_tilleuls_forgot_password.groups', $config['groups']);
+        $container->setParameter('coop_tilleuls_forgot_password.password_token_class', $config['password_token']['class']);
+        $container->setParameter('coop_tilleuls_forgot_password.password_token_expires_in', $config['password_token']['expires_in']);
+        $container->setParameter('coop_tilleuls_forgot_password.password_token_user_field', $config['password_token']['user_field']);
+        $container->setParameter('coop_tilleuls_forgot_password.password_token_serialization_groups', $config['password_token']['serialization_groups']);
+
+        $container->setParameter('coop_tilleuls_forgot_password.user_class', $config['user']['class']);
+        $container->setParameter('coop_tilleuls_forgot_password.user_email_field', $config['user']['email_field']);
+        $container->setParameter('coop_tilleuls_forgot_password.user_password_field', $config['user']['password_field']);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');

--- a/Manager/PasswordTokenManager.php
+++ b/Manager/PasswordTokenManager.php
@@ -11,18 +11,33 @@ class PasswordTokenManager
 {
     private $manager;
     private $passwordTokenClass;
+    private $userClass;
+    private $userEmailField;
     private $defaultExpiresIn;
+    private $passwordTokenUserField;
 
     /**
      * @param ManagerInterface $manager
      * @param string           $passwordTokenClass
+     * @param string           $userClass
+     * @param string           $userEmailField
      * @param string           $defaultExpiresIn
+     * @param string           $passwordTokenUserField
      */
-    public function __construct(ManagerInterface $manager, $passwordTokenClass, $defaultExpiresIn)
-    {
+    public function __construct(
+        ManagerInterface $manager,
+        $passwordTokenClass,
+        $userClass,
+        $userEmailField,
+        $defaultExpiresIn,
+        $passwordTokenUserField
+    ) {
         $this->manager = $manager;
         $this->passwordTokenClass = $passwordTokenClass;
+        $this->userClass = $userClass;
+        $this->userEmailField = $userEmailField;
         $this->defaultExpiresIn = $defaultExpiresIn;
+        $this->passwordTokenUserField = $passwordTokenUserField;
     }
 
     /**
@@ -56,5 +71,15 @@ class PasswordTokenManager
     public function findOneByToken($token)
     {
         return $this->manager->findOneBy($this->passwordTokenClass, ['token' => $token]);
+    }
+
+    /**
+     * @param mixed $user
+     *
+     * @return AbstractPasswordToken
+     */
+    public function findOneByUser($user)
+    {
+        return $this->manager->findOneBy($this->passwordTokenClass, [$this->passwordTokenUserField => $user]);
     }
 }

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -10,23 +10,27 @@
             <argument type="service" id="coop_tilleuls_forgot_password.manager.password_token" />
             <argument type="service" id="validator" />
             <argument type="service" id="serializer" />
-            <argument>%coop_tilleuls_forgot_password.groups%</argument>
-            <argument>%coop_tilleuls_forgot_password.email_field%</argument>
-            <argument>%coop_tilleuls_forgot_password.password_field%</argument>
+            <argument>%coop_tilleuls_forgot_password.password_token_serialization_groups%</argument>
+            <argument>%coop_tilleuls_forgot_password.user_email_field%</argument>
+            <argument>%coop_tilleuls_forgot_password.user_password_field%</argument>
         </service>
 
         <service id="coop_tilleuls_forgot_password.manager.forgot_password" class="CoopTilleuls\ForgotPasswordBundle\Manager\ForgotPasswordManager">
             <argument type="service" id="coop_tilleuls_forgot_password.manager.password_token" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="coop_tilleuls_forgot_password.manager" />
+            <argument type="service" id="validator" />
             <argument>%coop_tilleuls_forgot_password.user_class%</argument>
-            <argument>%coop_tilleuls_forgot_password.email_field%</argument>
+            <argument>%coop_tilleuls_forgot_password.user_email_field%</argument>
         </service>
 
         <service id="coop_tilleuls_forgot_password.manager.password_token" class="CoopTilleuls\ForgotPasswordBundle\Manager\PasswordTokenManager">
             <argument type="service" id="coop_tilleuls_forgot_password.manager" />
             <argument>%coop_tilleuls_forgot_password.password_token_class%</argument>
-            <argument>%coop_tilleuls_forgot_password.expires_in%</argument>
+            <argument>%coop_tilleuls_forgot_password.user_class%</argument>
+            <argument>%coop_tilleuls_forgot_password.user_email_field%</argument>
+            <argument>%coop_tilleuls_forgot_password.password_token_expires_in%</argument>
+            <argument>%coop_tilleuls_forgot_password.password_token_user_field%</argument>
         </service>
 
         <service id="coop_tilleuls_forgot_password.manager.doctrine" class="CoopTilleuls\ForgotPasswordBundle\Manager\Bridge\DoctrineManager" public="false">

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -56,6 +56,22 @@ class FeatureContext implements Context, SnippetAcceptingContext
     }
 
     /**
+     * @Given I have a valid token
+     */
+    public function iHaveAValidToken()
+    {
+        $this->passwordTokenManager->createPasswordToken($this->createUser());
+    }
+
+    /**
+     * @Given I have an expired token
+     */
+    public function iHaveAnExpiredToken()
+    {
+        $this->passwordTokenManager->createPasswordToken($this->createUser(), new \DateTime('-1 minute'));
+    }
+
+    /**
      * @Then I reset my password
      */
     public function iResetMyPassword()

--- a/features/forgotPassword.feature
+++ b/features/forgotPassword.feature
@@ -4,6 +4,16 @@ Feature: I need to be able to reset my password
         When I reset my password
         Then I should receive an email
 
+    Scenario: I can't reset my password if I already request a token
+        Given I have a valid token
+        When I reset my password
+        Then the request should be invalid
+
+    Scenario: I can reset my password if I already request a token but it has expired
+        Given I have an expired token
+        When I reset my password
+        Then I should receive an email
+
     Scenario: I can't reset my password with an invalid email address
         When I reset my password using invalid email address
         Then the request should be invalid


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #13
| License       | MIT

Configuration has been revamp as following (default):
```yml
coop_tilleuls_forgot_password:
    manager: coop_tilleuls_forgot_password.manager.doctrine
    password_token:
        class: AppBundle\Entity\PasswordToken
        expires_in: 1 day
        user_field: user
        serialization_groups: []
    user:
        class: AppBundle\Entity\User
        email_field: email
        password_field: password
```

But it's also available for minimal required configuration as following:
```yml
coop_tilleuls_forgot_password:
    password_token_class: AppBundle\Entity\PasswordToken
    user_class: AppBundle\Entity\User
```