### PR TITLE
hotfix: better string generation with random_bytes

### DIFF
--- a/Manager/PasswordTokenManager.php
+++ b/Manager/PasswordTokenManager.php
@@ -56,7 +56,7 @@ class PasswordTokenManager
         $passwordToken = new $this->passwordTokenClass();
 
         if (version_compare(phpversion(), '7.0', '>')) {
-            $passwordToken->setToken(random_bytes(50));
+            $passwordToken->setToken(bin2hex(random_bytes(50)));
         } else {
             $factory = new Factory();
             $generator = $factory->getGenerator(new Strength(Strength::MEDIUM));


### PR DESCRIPTION
Missing bin2hex to have strings only

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

