### PR TITLE
Add config default for the JMS serializer usage

### DIFF
--- a/Resources/doc/getting_started.md
+++ b/Resources/doc/getting_started.md
@@ -147,6 +147,7 @@ coop_tilleuls_forgot_password:
         class: App\Entity\User # required
         email_field: email
         password_field: password
+    use_jms_serialize: false # Switch between symfony's serializer component or JMS Serializer
 ```
 
 ## Ensure user is not authenticated


### PR DESCRIPTION
Hi @vincentchalamon :)

A config key (`use_jms_serializer`) was missing in the documentation.

| Q             | A
| ------------- | ---
| Bug fix?      | somehow
| New feature?  | definitely not
| BC breaks?    | not at all
| Deprecations? | even less
| Tests pass?   | I bet
| Fixed tickets | none
| License       | MIT

*Please update this template with something that matches your PR* <= good hint!
