### PR TITLE
Token length = 50

### DIFF
--- a/Resources/config/doctrine/AbstractPasswordToken.orm.xml
+++ b/Resources/config/doctrine/AbstractPasswordToken.orm.xml
@@ -3,7 +3,7 @@
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping http://doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
     <mapped-superclass name="CoopTilleuls\ForgotPasswordBundle\Entity\AbstractPasswordToken">
-        <field name="token" type="string" column="token" length="255" nullable="false" unique="true"/>
+        <field name="token" type="string" column="token" length="50" nullable="false" unique="true"/>
         <field name="expiresAt" type="datetime" column="expires_at" nullable="false"/>
     </mapped-superclass>
 </doctrine-mapping>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

I had an issue try to create the table on a MySql datatable. There was a problem creating the Unique index : #1071 - Specified key was too long; max key length is xxx bytes 

Solve the problem by reducing varchar length.