### PR TITLE
Fixed typo in documentation

### DIFF
--- a/Resources/doc/getting_started.md
+++ b/Resources/doc/getting_started.md
@@ -147,7 +147,7 @@ coop_tilleuls_forgot_password:
         class: App\Entity\User # required
         email_field: email
         password_field: password
-    use_jms_serialize: false # Switch between symfony's serializer component or JMS Serializer
+    use_jms_serializer: false # Switch between symfony's serializer component or JMS Serializer
 ```
 
 ## Ensure user is not authenticated


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #45 
| License       | CC0

This PR just fixes a typo revealed but still unfixed in https://github.com/coopTilleuls/CoopTilleulsForgotPasswordBundle/issues/45#issuecomment-425673326 :smile: 