### PR TITLE
Add ApiPlatform bridge

### DIFF
--- a/Bridge/ApiPlatform/Serializer/DocumentationNormalizer.php
+++ b/Bridge/ApiPlatform/Serializer/DocumentationNormalizer.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * This file is part of the CoopTilleulsForgotPasswordBundle package.
+ *
+ * (c) Vincent Chalamon <vincent@les-tilleuls.coop>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace CoopTilleuls\ForgotPasswordBundle\Bridge\ApiPlatform\Serializer;
+
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ */
+final class DocumentationNormalizer implements NormalizerInterface
+{
+    private $decorated;
+
+    public function __construct(NormalizerInterface $decorated)
+    {
+        $this->decorated = $decorated;
+    }
+
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $docs = $this->decorated->normalize($object, $format, $context);
+
+        // Add POST /forgot-password/ path
+        $docs['tags'][] = ['name' => 'Forgot password'];
+        $docs['paths']['/forgot-password/']['post'] = [
+            'tags' => ['Forgot password'],
+            'operationId' => 'postForgotPassword',
+            'summary' => 'Generates a token and send email',
+            'responses' => [
+                204 => [
+                    'description' => 'Valid email address, no matter if user exists or not',
+                ],
+                400 => [
+                    'description' => 'Missing email parameter or invalid format',
+                ],
+            ],
+            'requestBody' => [
+                'description' => 'Request a new password',
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            '$ref' => '#/components/schemas/ForgotPassword:request',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $docs['components']['schemas']['ForgotPassword:request'] = [
+            'type' => 'object',
+            'description' => '',
+            'required' => ['email'],
+            'properties' => [
+                'email' => [
+                    'type' => 'string',
+                ],
+            ],
+        ];
+
+        // Add GET /forgot-password/{token} path
+        $docs['paths']['/forgot-password/{token}']['get'] = [
+            'tags' => ['Forgot password'],
+            'operationId' => 'getForgotPassword',
+            'summary' => 'Validates token',
+            'responses' => [
+                200 => [
+                    'description' => 'Authenticated user',
+                    'content' => [
+                        'application/json' => [
+                            'schema' => [
+                                '$ref' => '#/components/schemas/ForgotPassword:validate',
+                            ],
+                        ],
+                    ],
+                ],
+                404 => [
+                    'description' => 'Token not found or expired',
+                ],
+            ],
+            'parameters' => [
+                [
+                    'name' => 'token',
+                    'in' => 'path',
+                    'required' => true,
+                    'schema' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+        ];
+        $docs['components']['schemas']['ForgotPassword:validate'] = [
+            'type' => 'object',
+            'description' => '',
+        ];
+
+        // Add POST /forgot-password/{token} path
+        $docs['paths']['/forgot-password/{token}']['post'] = [
+            'tags' => ['Forgot password'],
+            'operationId' => 'postForgotPasswordToken',
+            'summary' => 'Resets user password from token',
+            'responses' => [
+                204 => [
+                    'description' => 'Email address format valid, no matter if user exists or not',
+                ],
+                400 => [
+                    'description' => 'Missing password parameter',
+                ],
+                404 => [
+                    'description' => 'Token not found',
+                ],
+            ],
+            'parameters' => [
+                [
+                    'name' => 'token',
+                    'in' => 'path',
+                    'required' => true,
+                    'schema' => [
+                        'type' => 'string',
+                    ],
+                ],
+            ],
+            'requestBody' => [
+                'description' => 'Reset password',
+                'content' => [
+                    'application/json' => [
+                        'schema' => [
+                            '$ref' => '#/components/schemas/ForgotPassword:reset',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $docs['components']['schemas']['ForgotPassword:reset'] = [
+            'type' => 'object',
+            'description' => '',
+            'required' => ['password'],
+            'properties' => [
+                'password' => [
+                    'type' => 'string',
+                ],
+            ],
+        ];
+
+        return $docs;
+    }
+
+    public function supportsNormalization($data, $format = null)
+    {
+        return $this->decorated->supportsNormalization($data, $format);
+    }
+}

--- a/DependencyInjection/CoopTilleulsForgotPasswordExtension.php
+++ b/DependencyInjection/CoopTilleulsForgotPasswordExtension.php
@@ -48,6 +48,11 @@ final class CoopTilleulsForgotPasswordExtension extends Extension
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
+        // Load API-Platform bridge
+        if (isset($container->getParameter('kernel.bundles')['ApiPlatformBundle'])) {
+            $loader->load('api_platform.xml');
+        }
+
         // Build manager
         if (!$container->hasDefinition($config['manager'])) {
             throw new \LogicException(sprintf('Service "%s" does not exist.', $config['manager']));

--- a/Resources/config/api_platform.xml
+++ b/Resources/config/api_platform.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services
+        http://symfony.com/schema/dic/services/services-1.0.xsd">
+    <services>
+        <service id="coop_tilleuls_forgot_password.normalizer.documentation" public="true"
+                 decorates="api_platform.swagger.normalizer.documentation"
+                 class="CoopTilleuls\ForgotPasswordBundle\Bridge\ApiPlatform\Serializer\DocumentationNormalizer">
+            <argument type="service" id="coop_tilleuls_forgot_password.normalizer.documentation.inner"/>
+        </service>
+    </services>
+</container>

--- a/tests/Bridge/ApiPlatform/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Bridge/ApiPlatform/Serializer/DocumentationNormalizerTest.php
@@ -21,7 +21,7 @@ use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 final class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var ObjectProphecy|NormalizerInterface
+     * @var NormalizerInterface|ObjectProphecy
      */
     private $normalizerMock;
 

--- a/tests/Bridge/ApiPlatform/Serializer/DocumentationNormalizerTest.php
+++ b/tests/Bridge/ApiPlatform/Serializer/DocumentationNormalizerTest.php
@@ -1,0 +1,259 @@
+<?php
+
+/*
+ * This file is part of the CoopTilleulsForgotPasswordBundle package.
+ *
+ * (c) Vincent Chalamon <vincent@les-tilleuls.coop>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\ForgotPasswordBundle\Bridge\ApiPlatform\Serializer;
+
+use CoopTilleuls\ForgotPasswordBundle\Bridge\ApiPlatform\Serializer\DocumentationNormalizer;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * @author Vincent Chalamon <vincent@les-tilleuls.coop>
+ */
+final class DocumentationNormalizerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ObjectProphecy|NormalizerInterface
+     */
+    private $normalizerMock;
+
+    /**
+     * @var DocumentationNormalizer
+     */
+    private $normalizer;
+
+    protected function setUp()
+    {
+        $this->normalizerMock = $this->prophesize(NormalizerInterface::class);
+        $this->normalizer = new DocumentationNormalizer($this->normalizerMock->reveal());
+    }
+
+    public function testItSupportsDecoratedSupport()
+    {
+        $this->normalizerMock->supportsNormalization('foo', 'bar')->willReturn(true)->shouldBeCalledTimes(1);
+        $this->assertTrue($this->normalizer->supportsNormalization('foo', 'bar'));
+    }
+
+    public function testItDecoratesNormalizedData()
+    {
+        $this->normalizerMock->normalize(new \stdClass(), 'bar', [])->willReturn([
+            'tags' => [['name' => 'Login']],
+            'paths' => [
+                '/login' => [
+                    'post' => [
+                        'tags' => ['Login'],
+                        'operationId' => 'login',
+                        'summary' => 'Log in',
+                        'responses' => [
+                            204 => [
+                                'description' => 'Valid credentials',
+                            ],
+                            400 => [
+                                'description' => 'Invalid credentials',
+                            ],
+                        ],
+                        'requestBody' => [
+                            'description' => 'Log in',
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => [
+                                        '$ref' => '#/components/schemas/User:login',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'schemas' => [
+                    'User:login' => [
+                        'type' => 'object',
+                        'description' => '',
+                        'required' => ['username', 'password'],
+                        'properties' => [
+                            'username' => [
+                                'type' => 'string',
+                            ],
+                            'password' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ])->shouldBeCalledTimes(1);
+        $this->assertEquals([
+            'tags' => [['name' => 'Login'], ['name' => 'Forgot password']],
+            'paths' => [
+                '/login' => [
+                    'post' => [
+                        'tags' => ['Login'],
+                        'operationId' => 'login',
+                        'summary' => 'Log in',
+                        'responses' => [
+                            204 => [
+                                'description' => 'Valid credentials',
+                            ],
+                            400 => [
+                                'description' => 'Invalid credentials',
+                            ],
+                        ],
+                        'requestBody' => [
+                            'description' => 'Log in',
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => [
+                                        '$ref' => '#/components/schemas/User:login',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                '/forgot-password/' => [
+                    'post' => [
+                        'tags' => ['Forgot password'],
+                        'operationId' => 'postForgotPassword',
+                        'summary' => 'Generates a token and send email',
+                        'responses' => [
+                            204 => [
+                                'description' => 'Valid email address, no matter if user exists or not',
+                            ],
+                            400 => [
+                                'description' => 'Missing email parameter or invalid format',
+                            ],
+                        ],
+                        'requestBody' => [
+                            'description' => 'Request a new password',
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => [
+                                        '$ref' => '#/components/schemas/ForgotPassword:request',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+                '/forgot-password/{token}' => [
+                    'get' => [
+                        'tags' => ['Forgot password'],
+                        'operationId' => 'getForgotPassword',
+                        'summary' => 'Validates token',
+                        'responses' => [
+                            200 => [
+                                'description' => 'Authenticated user',
+                                'content' => [
+                                    'application/json' => [
+                                        'schema' => [
+                                            '$ref' => '#/components/schemas/ForgotPassword:validate',
+                                        ],
+                                    ],
+                                ],
+                            ],
+                            404 => [
+                                'description' => 'Token not found or expired',
+                            ],
+                        ],
+                        'parameters' => [
+                            [
+                                'name' => 'token',
+                                'in' => 'path',
+                                'required' => true,
+                                'schema' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                        ],
+                    ],
+                    'post' => [
+                        'tags' => ['Forgot password'],
+                        'operationId' => 'postForgotPasswordToken',
+                        'summary' => 'Resets user password from token',
+                        'responses' => [
+                            204 => [
+                                'description' => 'Email address format valid, no matter if user exists or not',
+                            ],
+                            400 => [
+                                'description' => 'Missing password parameter',
+                            ],
+                            404 => [
+                                'description' => 'Token not found',
+                            ],
+                        ],
+                        'parameters' => [
+                            [
+                                'name' => 'token',
+                                'in' => 'path',
+                                'required' => true,
+                                'schema' => [
+                                    'type' => 'string',
+                                ],
+                            ],
+                        ],
+                        'requestBody' => [
+                            'description' => 'Reset password',
+                            'content' => [
+                                'application/json' => [
+                                    'schema' => [
+                                        '$ref' => '#/components/schemas/ForgotPassword:reset',
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            'components' => [
+                'schemas' => [
+                    'User:login' => [
+                        'type' => 'object',
+                        'description' => '',
+                        'required' => ['username', 'password'],
+                        'properties' => [
+                            'username' => [
+                                'type' => 'string',
+                            ],
+                            'password' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                    'ForgotPassword:request' => [
+                        'type' => 'object',
+                        'description' => '',
+                        'required' => ['email'],
+                        'properties' => [
+                            'email' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                    'ForgotPassword:validate' => [
+                        'type' => 'object',
+                        'description' => '',
+                    ],
+                    'ForgotPassword:reset' => [
+                        'type' => 'object',
+                        'description' => '',
+                        'required' => ['password'],
+                        'properties' => [
+                            'password' => [
+                                'type' => 'string',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], $this->normalizer->normalize(new \stdClass(), 'bar'));
+    }
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

- [x] Decorates `api_platform.swagger.normalizer.documentation` to add ForgotPassword configuration
- [x] Autodetect if ApiPlatformBundle is loaded, then load this normalizer