### PR TITLE
remove documentation definition if not enabled in api platform

### DIFF
--- a/DependencyInjection/CoopTilleulsForgotPasswordExtension.php
+++ b/DependencyInjection/CoopTilleulsForgotPasswordExtension.php
@@ -61,5 +61,9 @@ final class CoopTilleulsForgotPasswordExtension extends Extension
         $class = true === $config['use_jms_serializer'] ? JMSNormalizer::class : SymfonyNormalizer::class;
         $serializerId = true === $config['use_jms_serializer'] ? 'jms_serializer.serializer' : 'serializer';
         $container->setDefinition('coop_tilleuls_forgot_password.normalizer', new Definition($class, [new Reference($serializerId)]))->setPublic(false);
+
+        if (!$container->hasDefinition('api_platform.swagger.normalizer.documentation')) {
+            $container->removeDefinition('coop_tilleuls_forgot_password.normalizer.documentation');
+        }
     }
 }


### PR DESCRIPTION
When using this bundle without documentation, symfony would complain about missing dependency for api_platform.swagger.normalizer.documentation 


| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
