### PR TITLE
Send is void

### DIFF
--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -55,9 +55,7 @@ final class ForgotPasswordEventSubscriber implements EventSubscriberInterface
                     'reset_password_url' => sprintf('http://www.example.com/forgot-password/%s', $passwordToken->getToken()),
                 ]
             ));
-        if (0 === $this->mailer->send($message)) {
-            throw new \RuntimeException('Unable to send email');
-        }
+        $this->mailer->send($message);
     }
 }
 ```


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | 
| License       | MIT

Send() in MailerInterface is a void method.