### PR TITLE
fix (AbstractPasswordToken): remove getId return type

### DIFF
--- a/Entity/AbstractPasswordToken.php
+++ b/Entity/AbstractPasswordToken.php
@@ -28,9 +28,6 @@ abstract class AbstractPasswordToken
      */
     protected $expiresAt;
 
-    /**
-     * @return int
-     */
     abstract public function getId();
 
     abstract public function getUser();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | ~
| License       | MIT

It could be a string and still be valid.
The motivation comes from tier code static analysis validation.
The "signatures" does not match but the use case seems alright, it's more like phpstan rely on the phpdoc which is inacurate.
