### PR TITLE
Replace tokenValue by token to unify the parameter name

### DIFF
--- a/EventListener/RequestEventListener.php
+++ b/EventListener/RequestEventListener.php
@@ -105,7 +105,7 @@ final class RequestEventListener
             return;
         }
 
-        $token = $this->passwordTokenManager->findOneByToken($request->attributes->get('tokenValue'));
+        $token = $this->passwordTokenManager->findOneByToken($request->attributes->get('token'));
         if (null === $token || $token->isExpired()) {
             throw new NotFoundHttpException('Invalid token.');
         }

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -8,11 +8,11 @@
         <default key="_controller">coop_tilleuls_forgot_password.controller.reset_password</default>
     </route>
 
-    <route id="coop_tilleuls_forgot_password.update" path="/{tokenValue}" methods="POST">
+    <route id="coop_tilleuls_forgot_password.update" path="/{token}" methods="POST">
         <default key="_controller">coop_tilleuls_forgot_password.controller.update_password</default>
     </route>
 
-    <route id="coop_tilleuls_forgot_password.get_token" path="/{tokenValue}" methods="GET">
+    <route id="coop_tilleuls_forgot_password.get_token" path="/{token}" methods="GET">
         <default key="_controller">coop_tilleuls_forgot_password.controller.get_token</default>
     </route>
 

--- a/Resources/doc/getting_started.md
+++ b/Resources/doc/getting_started.md
@@ -136,7 +136,7 @@ If you want, for instance, to return an empty response, you can easily override 
 # ...
 
 coop_tilleuls_forgot_password.get_token:
-    path: /forgot-password/{tokenValue}
+    path: /forgot-password/{token}
     methods: [ GET ]
     defaults:
         _controller: App\Controller\GetTokenController

--- a/tests/EventListener/RequestEventListenerTest.php
+++ b/tests/EventListener/RequestEventListenerTest.php
@@ -175,7 +175,7 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('tokenValue')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->shouldBeCalledOnce();
 
         $this->listener->getTokenFromRequest($this->eventMock->reveal());
@@ -193,7 +193,7 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('tokenValue')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
         $tokenMock->isExpired()->willReturn(true)->shouldBeCalledOnce();
 
@@ -210,7 +210,7 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('tokenValue')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
         $tokenMock->isExpired()->willReturn(false)->shouldBeCalledOnce();
         $this->parameterBagMock->set('token', $tokenMock->reveal())->shouldBeCalledOnce();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | maybe
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #100
| License       | MIT
