### PR TITLE
Replace tokenValue by token to unify the parameter name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ composer.lock
 phpunit.xml
 clover.xml
 var
-/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ composer.lock
 phpunit.xml
 clover.xml
 var
+/.idea

--- a/EventListener/RequestEventListener.php
+++ b/EventListener/RequestEventListener.php
@@ -106,8 +106,8 @@ final class RequestEventListener
         }
 
         // BC
-        if (!$request->attributes->has('token')) {
-            $request->attributes->set('token', $request->attributes->get('tokenValue'));
+        if (!$request->attributes->has('tokenValue')) {
+            $request->attributes->set('tokenValue', $request->attributes->get('token'));
         }
         $token = $this->passwordTokenManager->findOneByToken($request->attributes->get('token'));
         if (null === $token || $token->isExpired()) {

--- a/EventListener/RequestEventListener.php
+++ b/EventListener/RequestEventListener.php
@@ -105,6 +105,10 @@ final class RequestEventListener
             return;
         }
 
+        // BC
+        if (!$request->attributes->has('token')) {
+            $request->attributes->set('token', $request->attributes->get('tokenValue'));
+        }
         $token = $this->passwordTokenManager->findOneByToken($request->attributes->get('token'));
         if (null === $token || $token->isExpired()) {
             throw new NotFoundHttpException('Invalid token.');

--- a/EventListener/RequestEventListener.php
+++ b/EventListener/RequestEventListener.php
@@ -105,7 +105,7 @@ final class RequestEventListener
             return;
         }
 
-        $token = $this->passwordTokenManager->findOneByToken($request->attributes->get('tokenValue'));
+        $token = $this->passwordTokenManager->findOneByToken($request->attributes->get('token'));
         if (null === $token || $token->isExpired()) {
             throw new NotFoundHttpException('Invalid token.');
         }

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -8,11 +8,11 @@
         <default key="_controller">coop_tilleuls_forgot_password.controller.reset_password</default>
     </route>
 
-    <route id="coop_tilleuls_forgot_password.update" path="/{tokenValue}" methods="POST">
+    <route id="coop_tilleuls_forgot_password.update" path="/{token}" methods="POST">
         <default key="_controller">coop_tilleuls_forgot_password.controller.update_password</default>
     </route>
 
-    <route id="coop_tilleuls_forgot_password.get_token" path="/{tokenValue}" methods="GET">
+    <route id="coop_tilleuls_forgot_password.get_token" path="/{token}" methods="GET">
         <default key="_controller">coop_tilleuls_forgot_password.controller.get_token</default>
     </route>
 

--- a/Resources/doc/getting_started.md
+++ b/Resources/doc/getting_started.md
@@ -136,7 +136,7 @@ If you want, for instance, to return an empty response, you can easily override 
 # ...
 
 coop_tilleuls_forgot_password.get_token:
-    path: /forgot-password/{tokenValue}
+    path: /forgot-password/{token}
     methods: [ GET ]
     defaults:
         _controller: App\Controller\GetTokenController

--- a/tests/EventListener/RequestEventListenerTest.php
+++ b/tests/EventListener/RequestEventListenerTest.php
@@ -175,7 +175,10 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledTimes(2);
+        // BC
+        $this->parameterBagMock->has('tokenValue')->willReturn(false)->shouldBeCalledOnce();
+        $this->parameterBagMock->set('tokenValue', 'foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->shouldBeCalledOnce();
 
         $this->listener->getTokenFromRequest($this->eventMock->reveal());
@@ -193,7 +196,10 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledTimes(2);
+        // BC
+        $this->parameterBagMock->has('tokenValue')->willReturn(false)->shouldBeCalledOnce();
+        $this->parameterBagMock->set('tokenValue', 'foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
         $tokenMock->isExpired()->willReturn(true)->shouldBeCalledOnce();
 
@@ -210,29 +216,13 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledTimes(2);
+        // BC
+        $this->parameterBagMock->has('tokenValue')->willReturn(false)->shouldBeCalledOnce();
+        $this->parameterBagMock->set('tokenValue', 'foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
         $tokenMock->isExpired()->willReturn(false)->shouldBeCalledOnce();
         $this->parameterBagMock->set('token', $tokenMock->reveal())->shouldBeCalledOnce();
-
-        $this->listener->getTokenFromRequest($this->eventMock->reveal());
-    }
-
-    // BC
-    public function testGetTokenValueFromRequest(): void
-    {
-        $tokenMock = $this->prophesize(AbstractPasswordToken::class);
-
-        $this->parameterBagMock->get('_route')->willReturn('coop_tilleuls_forgot_password.update')->shouldBeCalledOnce();
-        if (method_exists(KernelEvent::class, 'isMainRequest')) {
-            $this->eventMock->isMainRequest()->willReturn(true)->shouldBeCalledOnce();
-        } else {
-            $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
-        }
-        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
-        $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
-        $tokenMock->isExpired()->willReturn(false)->shouldBeCalledOnce();
-        $this->parameterBagMock->set('tokenValue', $tokenMock->reveal())->shouldBeCalledOnce();
 
         $this->listener->getTokenFromRequest($this->eventMock->reveal());
     }

--- a/tests/EventListener/RequestEventListenerTest.php
+++ b/tests/EventListener/RequestEventListenerTest.php
@@ -229,7 +229,7 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('tokenValue')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
         $tokenMock->isExpired()->willReturn(false)->shouldBeCalledOnce();
         $this->parameterBagMock->set('tokenValue', $tokenMock->reveal())->shouldBeCalledOnce();

--- a/tests/EventListener/RequestEventListenerTest.php
+++ b/tests/EventListener/RequestEventListenerTest.php
@@ -217,4 +217,23 @@ final class RequestEventListenerTest extends TestCase
 
         $this->listener->getTokenFromRequest($this->eventMock->reveal());
     }
+
+    // BC
+    public function testGetTokenValueFromRequest(): void
+    {
+        $tokenMock = $this->prophesize(AbstractPasswordToken::class);
+
+        $this->parameterBagMock->get('_route')->willReturn('coop_tilleuls_forgot_password.update')->shouldBeCalledOnce();
+        if (method_exists(KernelEvent::class, 'isMainRequest')) {
+            $this->eventMock->isMainRequest()->willReturn(true)->shouldBeCalledOnce();
+        } else {
+            $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
+        }
+        $this->parameterBagMock->get('tokenValue')->willReturn('foo')->shouldBeCalledOnce();
+        $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
+        $tokenMock->isExpired()->willReturn(false)->shouldBeCalledOnce();
+        $this->parameterBagMock->set('tokenValue', $tokenMock->reveal())->shouldBeCalledOnce();
+
+        $this->listener->getTokenFromRequest($this->eventMock->reveal());
+    }
 }

--- a/tests/EventListener/RequestEventListenerTest.php
+++ b/tests/EventListener/RequestEventListenerTest.php
@@ -175,7 +175,7 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('tokenValue')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->shouldBeCalledOnce();
 
         $this->listener->getTokenFromRequest($this->eventMock->reveal());
@@ -193,7 +193,7 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('tokenValue')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
         $tokenMock->isExpired()->willReturn(true)->shouldBeCalledOnce();
 
@@ -210,7 +210,7 @@ final class RequestEventListenerTest extends TestCase
         } else {
             $this->eventMock->isMasterRequest()->willReturn(true)->shouldBeCalledOnce();
         }
-        $this->parameterBagMock->get('tokenValue')->willReturn('foo')->shouldBeCalledOnce();
+        $this->parameterBagMock->get('token')->willReturn('foo')->shouldBeCalledOnce();
         $this->managerMock->findOneByToken('foo')->willReturn($tokenMock->reveal())->shouldBeCalledOnce();
         $tokenMock->isExpired()->willReturn(false)->shouldBeCalledOnce();
         $this->parameterBagMock->set('token', $tokenMock->reveal())->shouldBeCalledOnce();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | not yet
| Fixed tickets | #100
| License       | MIT

Basically the same as #101 but with bc compatibility and targeting 1.4
